### PR TITLE
[I] Удаление пробелов из значений

### DIFF
--- a/assets/snippets/eFilter/eFilter.class.php
+++ b/assets/snippets/eFilter/eFilter.class.php
@@ -663,7 +663,7 @@ public function getFilterValues ($content_ids, $filter_tv_ids = '')
                     $filter_values[$row['tmplvarid']][$v]['count'] = 1;
                 }
             } else {
-                $tmp = explode("||", $row['value']);
+                $tmp = array_map('trim', explode("||", $row['value']));
                 foreach ($tmp as $v) {
                     if (isset($filter_values[$row['tmplvarid']][$v]['count'])) {
                         $filter_values[$row['tmplvarid']][$v]['count'] += 1;
@@ -695,7 +695,7 @@ public function getFilterFutureValues ($curr_filter_values, $filter_tv_ids = '')
                             $filter_values[$row['tmplvarid']][$v]['count'] = 1;
                         }
                     } else {
-                        $tmp = explode("||", $row['value']);
+                        $tmp = array_map('trim', explode("||", $row['value']));
                         foreach ($tmp as $v) {
                             if (isset($filter_values[$row['tmplvarid']][$v]['count'])) {
                                 $filter_values[$row['tmplvarid']][$v]['count'] += 1;


### PR DESCRIPTION
При использовании виджета mm_tags я столкнулся с тем, что он добавляет пробелы между значениями, хотя разделитель задан без пробелов:
<img src="https://monosnap.com/image/9Ys1kLgwwgig8IFId5BL6ROraPleWR.png">
И может возникнуть ситуация, когда одно и то же значение фильтром будет расценено как несколько разных именно из-за пробелов:
<img src="https://monosnap.com/image/UyVIBVtVkXaVg7drRvvJ5G0s01MZL1.png">